### PR TITLE
Simplify the inventory generation by removing the version specific code

### DIFF
--- a/ansible/README-cloud.md
+++ b/ansible/README-cloud.md
@@ -19,7 +19,7 @@
 - Generate the inventory host file containing the parameters used by the `openshift` like the IP address of the VM to ssh.
 
   ```bash
-  ansible-playbook playbook/generate_inventory.yml -e ip_address=192.168.99.50 -e openshift_origin_version=3.9
+  ansible-playbook playbook/generate_inventory.yml -e ip_address=192.168.99.50
   ```
   
   **WARNING**: Take care to supply the correct IP address in the corresponding argument !
@@ -32,7 +32,7 @@
   If another user other than `root` is to be used for accessing the machine over ssh, you can pass the `username` variable like so:
   
   ```bash
-  ansible-playbook playbook/generate_inventory.yml -e ip_address=192.168.99.50 -e openshift_origin_version=3.9 -e username=centos
+  ansible-playbook playbook/generate_inventory.yml -e ip_address=192.168.99.50 -e username=centos
   ```
 
 - Install OpenShift

--- a/ansible/playbook/roles/generate_inventory/templates/cloud.inventory.j2
+++ b/ansible/playbook/roles/generate_inventory/templates/cloud.inventory.j2
@@ -12,15 +12,9 @@ ansible_ssh_private_key_file={{ keyfile }}
 public_ip_address={{ ip_address }}
 host_key_checking=false
 
-{% if openshift_origin_version == '3.9' %}
 containerized=true
 openshift_enable_excluders=false
 openshift_release=v{{ openshift_origin_version }}
-{% else %}
-containerized=false
-openshift_release=v{{ openshift_origin_version }}
-openshift_pkg_version=-{{ openshift_origin_version }}.0
-{% endif %}
 
 openshift_deployment_type=origin
 

--- a/ansible/playbook/roles/openstack/tasks/main.yml
+++ b/ansible/playbook/roles/openstack/tasks/main.yml
@@ -62,7 +62,6 @@
       username: "{{ login_username }}"
       keyfile: "{{ private_key_in_inventory }}"
       hostname: "{{ openstack.vm.name }}"
-      openshift_origin_version: "3.9"
 
   - set_fact:
       internal_ssh_command: "ssh -o \"StrictHostKeyChecking=no\" -o \"UserKnownHostsFile=/dev/null\" -i {{ private_key_in_inventory }} -tt {{ login_username }}@{{ openstack_output.server.accessIPv4 }}"


### PR DESCRIPTION
We only support Openshift 3.9 anyway, so there is no point in trying
to create version specific inventories